### PR TITLE
Rubocop

### DIFF
--- a/linters/.rubocop.yml
+++ b/linters/.rubocop.yml
@@ -1,10 +1,10 @@
 AllCops:
-  Excludes:
+  Exclude:
     - script/*
     - db/*
     - tmp/*
     - vendor/*
-  Includes:
+  Include:
     - tasks/*.rake
   RunRailsCops: true
 
@@ -824,8 +824,8 @@ Output:
   Description: 'Checks for calls to puts, print, etc.'
   Enabled: false
 
-ReadAttribute:
-  Description: 'Prefer self[:attribute] over read_attribute(:attribute).'
+ReadWriteAttribute:
+  Description: 'Checks for read_attribute(:attr) and write_attribute(:attr, val)'
   Enabled: true
 
 ScopeArgs:


### PR DESCRIPTION
Rubocop is a tool that does automated style guide check. It's based on [same](https://github.com/bbatsov/ruby-style-guide) style guide we use as our own base. The provided `yml` is a base for setting Rubocop up on a new project and should be adjusted accordingly when creating a PR to change the Ruby style guide.
