### PR TITLE
Update language regarding idempotency

### DIFF
--- a/services.md
+++ b/services.md
@@ -76,7 +76,7 @@ In particular (but not limited to):
 
 - HTTP verbs should be used.
 - GET requests should have no side-effects (on any entity of this concept or others) and be cacheable.
-- POST and PATCH requests should be idempotent (requesting them more than once does not change state further)
+- PUT and PATCH requests should be idempotent (submitting them more than once should not change state further)
 - URL terms in any API should reflect domain concepts.
 - Hypermedia links should be provided in responses.
 


### PR DESCRIPTION
Small change, after a conversation with @mezis, to clarify GET, POST, PATCH idempotency.

This still raises a question in my mind about how the state of an entity for a particular hypermedia URL. Take, for example,`https://bookings.example.com/api/bookings/123`. The `123` in that URL implies an ID but, if the state of the object is fixed for each hypermedia URL in a response, then that is presumably some form of timestamp, or reference to an object at a particular moment in time, correct?

Also, how do we intend to manage storing the states across time? Is that an implementation detail for each service, or are we standardising on something like the audit gem [Papertrail](https://github.com/airblade/paper_trail), or (quite likely) have I misunderstood?
