### PR TITLE
A note about `specify` versus `it`

### DIFF
--- a/rspec.md
+++ b/rspec.md
@@ -64,11 +64,15 @@ it { subject be_published }
 
 ```ruby
 # bad
-it { subject.reivew.size.should eql(3) }
+it { subject.reviews.size.should eql(3) }
 
 # good
 it { should have(3).reviews }
 ```
+
+### `specify` versus `it`
+
+`specify` and `it` are aliases, you should prefer `it` as it reads better.
 
 ## Single expectations
 


### PR DESCRIPTION
Question: should we ever use `specify` over `it`?

Personally I have no opinion, both read well to me, buts `it` is shorter.

``` ruby
it { total_text.should == "1 available property" }

specify { total_text.should == "1 available property" }
```

With rspec 3 you can still use should syntax for oneliners:

``` ruby
it { total_text should eql("1 available property") }

specify { total_text should eql("1 available property") }
```
