### PR TITLE
Do not use shared examples

### DIFF
--- a/rspec.md
+++ b/rspec.md
@@ -212,7 +212,8 @@ Integration tests in Rspec live int the `spec/features` folder and need to be ta
 
 ## Shared examples
 
-TBD
+Do NOT use them. They make things DRY but the cost is too high. If it fails it makes things much more difficult to debug, and the error messages can be confusing.
+Also when used across files, it is less readable and making them reusable can become a challenge very fast.
 
 ## Custom matchers
 


### PR DESCRIPTION
I would like to start a discussion about shared examples. I already asked quickly on slack and it seems I am not the only one to feel the pain because of them. 

I am not sure yet if they should be totally banned or just banned across files (when they are put in `/support/shared_examples`).

So now, FIGHT

![image](http://i.imgur.com/nQZ7lbY.gif)
