### PR TITLE
Adds warning about using paginate on tables with many records

### DIFF
--- a/active-record.md
+++ b/active-record.md
@@ -171,9 +171,13 @@ Always **paginate or limit** unless domain knowledge tells you clearly you don't
 
 Good:
 
+```ruby
     User.offset((page - 1) * limit).limit(limit)
-    User.paginate(page:1, per_page:10)
-    User.limit(10)
+    # or 
+    User.paginate(page: page, per_page: limit)
+    # or
+    User.limit(limit)
+```
     
 Fine:
 

--- a/active-record.md
+++ b/active-record.md
@@ -165,10 +165,13 @@ If that isn't enough: precalculate, use caching, and **do your math in Ruby**. Y
 
 Rule of thumb: if you're not certain how many records your query will retrieve, eventually it's going to retreive too many and you'll blow up your machine's memory (known as _swapping_).
 
-Alway **paginate or limit** unless domain knowledge tells you clearly you don't have to.
+Always **paginate or limit** unless domain knowledge tells you clearly you don't have to.
+
+**But be aware** that when using `paginate` it does a `SELECT COUNT(*) ...` which can be very expensive in a table with many records, instead use `offset` and `limit`. 
 
 Good:
 
+    User.offset((page - 1) * limit).limit(limit)
     User.paginate(page:1, per_page:10)
     User.limit(10)
     


### PR DESCRIPTION
When you use `paginate` it will count all the records on the table so it knows how many pages it should show in the view, but that comes with a expensive cost if you have a big table. This can be a workaround if you don't care about how many pages to show.

https://github.com/mislav/will_paginate/issues/447
